### PR TITLE
Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.9"
 
 sphinx:
    configuration: doc/sphinx/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: doc/sphinx/source/conf.py
+
+python:
+   install:
+   - requirements: doc/sphinx/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Probe Particle Model (PPM)
 
+[![Documentation Status](https://readthedocs.org/projects/probeparticlemodel/badge/?version=main)](https://probeparticlemodel.readthedocs.io/en/main/?badge=main)
+
 Simple and efficient **simulation software for high-resolution atomic force microscopy** (**HR-AFM**) and other scanning probe microscopy (SPM) techniques with sub-molecular resolution (STM, IETS, TERS). It simulates deflection of the particle attached to the tip (typically CO molecule, but also e.g. Xe, Cl-, H2O and others).
 
 ### References

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 
 # Probe Particle Model (PPM)
 
-[![Documentation Status](https://readthedocs.org/projects/probeparticlemodel/badge/?version=main)](https://probeparticlemodel.readthedocs.io/en/main/?badge=main)
-
 Simple and efficient **simulation software for high-resolution atomic force microscopy** (**HR-AFM**) and other scanning probe microscopy (SPM) techniques with sub-molecular resolution (STM, IETS, TERS). It simulates deflection of the particle attached to the tip (typically CO molecule, but also e.g. Xe, Cl-, H2O and others).
 
-### References
-* [Prokop Hapala, Georgy Kichin, Christian Wagner, F. Stefan Tautz, Ruslan Temirov, and Pavel Jelínek, Mechanism of high-resolution STM/AFM imaging with functionalized tips, Phys. Rev. B 90, 085421 – Published 19 August 2014](http://journals.aps.org/prb/abstract/10.1103/PhysRevB.90.085421)
-* [Prokop Hapala, Ruslan Temirov, F. Stefan Tautz, and Pavel Jelínek, Origin of High-Resolution IETS-STM Images of Organic Molecules with Functionalized Tips, Phys. Rev. Lett. 113, 226101 – Published 25 November 2014,](http://journals.aps.org/prl/abstract/10.1103/PhysRevLett.113.226101) 
+### Further information
+- Publications: https://github.com/Probe-Particle/ProbeParticleModel#notable-publications-using-probe-particle-model
+- Wiki: https://github.com/Probe-Particle/ProbeParticleModel/wiki
+- API documentation: https://probeparticlemodel.readthedocs.io/en/main
 
 ## Flavors of PPM
 

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,0 +1,7 @@
+matplotlib
+numpy
+pyopencl
+reikna
+ase
+sphinx
+sphinx_rtd_theme

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -3,5 +3,5 @@ numpy
 pyopencl
 reikna
 ase
-sphinx
-sphinx_rtd_theme
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -6,6 +6,8 @@
 Welcome to Probe Particle Model's documentation!
 ================================================
 
+This is the API documentation for Probe Particle Model. It's a work-in-progress and many things are still missing. You can access the source code at `Github <https://github.com/Probe-Particle/ProbeParticleModel>`_. For an explanation of the simulation model and examples of usage, see the `wiki <https://github.com/Probe-Particle/ProbeParticleModel/wiki>`_.
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents:

--- a/doc/sphinx/source/pyProbeParticle.ocl.rst
+++ b/doc/sphinx/source/pyProbeParticle.ocl.rst
@@ -14,14 +14,6 @@ pyProbeParticle.ocl.AFMulator module
    :show-inheritance:
 .. autofunction:: pyProbeParticle.ocl.AFMulator.quick_afm
 
-pyProbeParticle.ocl.HighLevel module
-------------------------------------
-
-.. automodule:: pyProbeParticle.ocl.HighLevel
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 pyProbeParticle.ocl.field module
 --------------------------------
 

--- a/pyProbeParticle/ml/AuxMap.py
+++ b/pyProbeParticle/ml/AuxMap.py
@@ -8,18 +8,19 @@ from ..ocl import field    as FFcl
 from ..ocl import relax    as oclr
 
 class AuxMapBase:
-    '''
-    Base class for AuxMap subclasses.
+    '''Base class for AuxMap subclasses.
+
+    Each subclass implements the method `eval` with the input arguments:
+    
+    - xyzqs: numpy.ndarray of floats. xyz coordinates and charges of atoms in molecule
+    - Zs: numpy.ndarray of ints. Elements of atoms in molecule.
+    - pot: HartreePotential. Sample hartree potential.
+    - rot: np.ndarray of shape (3, 3). Sample rotation.
+
     Arguments:
         scan_dim: tuple of two ints. Indicates the pixel size of the scan in x and y.
         scan_window: tuple ((start_x, start_y), (end_x, end_y)). The start and end coordinates of scan region in angstroms.
-        zmin: float. Deepest coordinate that is still included. Top is defined to be at 0.
-        
-    Each subclass implements the method eval with the input arguments:
-        xyzqs: numpy.ndarray of floats. xyz coordinates and charges of atoms in molecule
-        Zs: numpy.ndarray of ints. Elements of atoms in molecule.
-        pot: HartreePotential. Sample hartree potential.
-        rot: np.ndarray of shape (3, 3). Sample rotation.
+        zmin: float. Deepest coordinate that is still included. Top is defined to be at 0. 
     '''
     def __init__(self, scan_dim, scan_window, zmin=None):
         if not FFcl.oclu:
@@ -51,6 +52,7 @@ class vdwSpheres(AuxMapBase):
     '''
     Generate vdW Spheres descriptors for molecules. Each atom is represented by a projection of a sphere 
     with radius equal to the vdW radius of the element.
+
     Arguments:
         Rpp: float. A constant that is added to the vdW radius of each atom.
     '''
@@ -67,6 +69,7 @@ class vdwSpheres(AuxMapBase):
 class AtomicDisks(AuxMapBase):
     '''
     Generate Atomic Disks descriptors for molecules. Each atom is represented by a conically decaying disk.
+
     Arguments:
         zmax_s: float. The maximum depth of vdW sphere shell when diskMode='sphere'.
         Rpp: float. A constant that is added to the vdW radius of each atom.
@@ -208,6 +211,7 @@ class MultiMapSpheres(AuxMapBase):
     Generate Multimap vdW Spheres descriptors for molecules. Each atom is represented by a projection of a sphere
     with radius equal to the vdW radius of the element. Different sizes of atoms are separated into different
     channels based on their vdW radii.
+    
     Arguments:
         Rpp: float. A constant that is added to the vdW radius of each atom.
         nChan: int. Number of channels.
@@ -234,6 +238,7 @@ class MultiMapSpheresElements(AuxMapBase):
     Generate Multimap vdW Spheres descriptors for molecules. Each atom is represented by a projection of a sphere
     with radius equal to the vdW radius of the element. Different elements can be separated arbitrarily into different
     channels.
+
     Arguments:
         Rpp: float. A constant that is added to the vdW radius of each atom.
         elems: list of lists of int or str. Lists of elements in each channel as the atomic numbers or symbols.
@@ -278,6 +283,7 @@ class MultiMapSpheresElements(AuxMapBase):
 class Bonds(AuxMapBase):
     '''
     Generate Bonds descriptors for molecules. Bonds between atoms are represented by ellipses.
+
     Arguments:
         Rfunc: numpy.ndarray. Radial function of bonds&atoms potential. Converted to numpy.float32
         Rmax: float. Cutoff in angstroms for radial function. Make sure is smaller than maximum range of Rfunc - 3*drStep.
@@ -309,6 +315,7 @@ class Bonds(AuxMapBase):
 class AtomRfunc(AuxMapBase):
     '''
     Generate AtomRfunc descriptors for molecules. Atoms are represented by disks with decay determined by Rfunc.
+
     Arguments:
         Rfunc: numpy.ndarray. Radial function of bonds&atoms potential. Converted to numpy.float32
         Rmax: float. Cutoff in angstroms for radial function. Make sure is smaller than maximum range of Rfunc - 3*drStep.

--- a/pyProbeParticle/ml/CorrectionLoop.py
+++ b/pyProbeParticle/ml/CorrectionLoop.py
@@ -34,7 +34,6 @@ from ..ocl import field    as FFcl
 from ..ocl import relax    as oclr
 from .. import SimplePot   as sp
 
-from ..ocl import HighLevel as hl
 from ..ocl import AFMulator
 from . import AuxMap
 from . import Generator


### PR DESCRIPTION
Fixes #40

This adds configuration files for readthedocs so that the API docs will automatically get rebuilt on every commit to the main branch and the result gets hosted on a web page that is accessible to everyone. Also added a badge to the README that links to the latest version of the docs (which does not work yet, before this is merged). The current test version can be viewed at https://probeparticlemodel.readthedocs.io/en/readthedocs/.