### PR TITLE
Simplified xyz IO functions

### DIFF
--- a/GUI/ppm-gui
+++ b/GUI/ppm-gui
@@ -616,8 +616,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
             qs, xyzs, Zs = hartreeFromFile(file_path)
             lvec = qs.lvec[1:]
         elif ext == '.xyz':
-            with open(file_path, 'r') as f:
-                xyzs, Zs, _, qs = basUtils.loadAtomsLines(f.readlines())
+            xyzs, Zs, qs, _ = basUtils.loadXYZ(file_path)
             lvec = None
         else:
             raise ValueError(f'Unsupported file format for file `{file_path}`.')

--- a/dev/FARFF/test_FARFF_AuxMaps.py
+++ b/dev/FARFF/test_FARFF_AuxMaps.py
@@ -23,10 +23,12 @@ import pyProbeParticle.FARFF as fff
 # =============== Setup
 
 if __name__ == "__main__":
+
+    from pyProbeParticle import basUtils
     import pyProbeParticle.atomicUtils as au
     import pyProbeParticle.GLView as glv
 
-    xyzs,Zs,elems,qs = au.loadAtomsNP("input.xyz")     #; print xyzs
+    xyzs, Zs, qs, _ = basUtils.loadXYZ("input.xyz")
 
     atomMapF, bondMapF, lvecMap = fff.makeGridFF( fff )
     print( " atomMapF ", atomMapF.shape, " bondMapF ", bondMapF.shape,  )

--- a/dev/bakup/subChgCore_cpp.py
+++ b/dev/bakup/subChgCore_cpp.py
@@ -41,10 +41,7 @@ elems = [ atoms[0][i] for i in inds ]   # atomic number of all relevant peridic 
 #elems +=  [2]*8
 #Rs_ = np.hstack( [Rs_,corners] )
 
-#BU.saveXyz_Transposed( "imaged_CO.xyz", elems, Rs_ )
 BU.saveGeomXSF( "imaged_CO.xsf",elems,Rs_, lvec[1:], convvec=lvec[1:], bTransposed=True )    # for debugging - mapping PBC images of atoms to the cell
-#BU.saveXyz( "imaged_CO.xyz", elems, Rs_ )
-#BU.saveXyz_Transposed( "imaged_CO.xyz", elems, Rs_ )
 
 #exit()
 

--- a/dev/test_MMFF.py
+++ b/dev/test_MMFF.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
 #import pyProbeParticle.PolyCycles  as pcff
 import pyProbeParticle.atomicUtils as au
 #import pyProbeParticle.chemistry   as ch
+from pyProbeParticle import basUtils
 
 import pyProbeParticle.MMFF   as mmff
 #include "DynamicOpt.h"
@@ -75,7 +76,7 @@ if __name__ == "__main__":
     type2elem  = [ 'U', 'U'  , 'He',  'Ne', 'H'  ]
     elems     +=  [  type2elem[-t] for t in types[natom0:] ]  ;print(elems) 
     
-    au.saveXYZ( elems, pos, "test_MMFF_start.xyz", qs=None )
+    basUtils.saveXYZ("test_MMFF_start.xyz", pos, elems)
     
     #exit()
     
@@ -85,7 +86,7 @@ if __name__ == "__main__":
         print(i," ", end=' ')
         f = mmff.relaxNsteps(1)
         errs.append( f )
-        au.writeToXYZ( fout, elems, pos )
+        basUtils.saveXYZ( fout, pos, elems )
         if(f<1e-6): break
     fout.close()
     

--- a/dev/test_PolyCycles2.py
+++ b/dev/test_PolyCycles2.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
 #import pyProbeParticle.PolyCycles  as pcff
 import pyProbeParticle.atomicUtils as au
 import pyProbeParticle.chemistry   as ch
+from pyProbeParticle import basUtils
 
 import matplotlib.pyplot as plt
 
@@ -340,7 +341,7 @@ if __name__ == "__main__":
     xyzs_g, elems_g = ch.groups2atoms( groups, neighs, xyzs )
     print("elems ", elems_g)
     print("elems ", xyzs_g)
-    au.saveXYZ( elems_g,xyzs_g, "test_PolyCycles_g.xyz" )
+    basUtils.saveXYZ("test_PolyCycles_g.xyz", xyzs_g, elems_g)
     
     # ======== Plot
     

--- a/dev/test_ReactiveFF.py
+++ b/dev/test_ReactiveFF.py
@@ -8,6 +8,7 @@ import time
 sys.path.append(os.path.split(sys.path[0])[0]) #;print(sys.path[-1])
 import pyProbeParticle.ReactiveFF  as rff
 import pyProbeParticle.atomicUtils as au
+from pyProbeParticle import basUtils
 
 #import matplotlib.pyplot as plt
 #from mpl_toolkits.mplot3d import Axes3D
@@ -111,7 +112,7 @@ if __name__ == "__main__":
         print("Qs        ", qs)
 
         #itypes_[itypes_==5] = 6 # replace borons by carbons
-        au.saveXYZ( itypes_, xyzs, dname+"/pos.xyz", qs=qs )
+        basUtils.saveXYZ(dname+"/pos.xyz", xyzs, itypes_, qs=qs )
 
         import matplotlib.pyplot as plt
         plt.scatter(xyzs[:,0], xyzs[:,1], c=qs, alpha=1.0, vmin=-0.5,vmax=0.5, cmap='bwr')

--- a/dev/test_atomicUtils.py
+++ b/dev/test_atomicUtils.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.append('..')
+import pyProbeParticle.atomicUtils as au
+
+def test_ZsToElems():
+
+    Zs = [3, 2, 1, 7, 8]
+    elems = au.ZsToElems(Zs)
+    assert elems == ['Li', 'He', 'H', 'N', 'O']
+
+if __name__ == '__main__':
+    test_ZsToElems()

--- a/dev/test_io.py
+++ b/dev/test_io.py
@@ -68,18 +68,6 @@ def test_parse_comment_ase():
     qs = _getCharges(comment, extra_cols)
     assert np.allclose(qs, np.zeros(10)), qs
 
-    extra_cols = [[-2], [2], [-0.1], [0.1]]
-    qs = _getCharges('', extra_cols)
-    assert np.allclose(qs, [-2, 2, -0.1, 0.1])
-
-    extra_cols = [[1], [1], [2], [2], [3], [3]]
-    qs = _getCharges('', extra_cols)
-    assert np.allclose(qs, np.zeros(6))
-
-    extra_cols = [[-3], [-2], [-1], [0], [1], [2], [3], [4]]
-    qs = _getCharges('', extra_cols)
-    assert np.allclose(qs, np.zeros(8))
-
 if __name__ == '__main__':
     test_xyz()
     test_parse_comment_ase()

--- a/dev/test_io.py
+++ b/dev/test_io.py
@@ -5,10 +5,11 @@ import sys
 import numpy as np
 
 sys.path.append('..')
-from pyProbeParticle.basUtils import loadXYZ, saveXYZ, parseCommentASE
-from pyProbeParticle.elements import ELEMENTS
 
 def test_xyz():
+
+    from pyProbeParticle.basUtils import loadXYZ, saveXYZ, _not_actually_charge
+    from pyProbeParticle.elements import ELEMENTS
 
     N = 20
     test_file = 'io_test.xyz'
@@ -31,9 +32,15 @@ def test_xyz():
     _, _, qs_, _ = loadXYZ(test_file)
     assert np.allclose(qs_, np.zeros(N))
 
+    assert _not_actually_charge([1, 1, 2, 2, 3, 3]) == True
+    assert _not_actually_charge([-3, -2, -1, 0, 1, 2, 3, 4]) == True
+    assert _not_actually_charge([-2, 2, -0.1, 0.1]) == False
+
     os.remove(test_file)
 
 def test_parse_comment_ase():
+
+    from pyProbeParticle.basUtils import parseCommentASE
 
     comment = 'Lattice="40.587929240107826 0.0 0.0 0.0 35.15017780893861 0.0 0.0 0.0 42.485492908861346" Properties=species:S:1:pos:R:3:tags:I:1 pbc="T T T"'
     lvec, has_charges = parseCommentASE(comment)

--- a/dev/test_io.py
+++ b/dev/test_io.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 
 sys.path.append('..')
-from pyProbeParticle.basUtils import loadXYZ, saveXYZ
+from pyProbeParticle.basUtils import loadXYZ, saveXYZ, parseCommentASE
 from pyProbeParticle.elements import ELEMENTS
 
 def test_xyz():
@@ -33,5 +33,25 @@ def test_xyz():
 
     os.remove(test_file)
 
+def test_parse_comment_ase():
+
+    comment = 'Lattice="40.587929240107826 0.0 0.0 0.0 35.15017780893861 0.0 0.0 0.0 42.485492908861346" Properties=species:S:1:pos:R:3:tags:I:1 pbc="T T T"'
+    lvec, has_charges = parseCommentASE(comment)
+    assert np.allclose(lvec,
+        np.array([
+            [ 0.0              ,  0.0             ,  0.0              ],
+            [40.587929240107826,  0.0             ,  0.0              ],
+            [ 0.0              , 35.15017780893861,  0.0              ],
+            [ 0.0              ,  0.0             , 42.485492908861346]
+        ], dtype=np.float32)
+    )
+    assert has_charges == False
+
+    comment = 'Properties=species:S:1:pos:R:3:initial_charges:R:1 pbc="F F F"'
+    lvec, has_charges = parseCommentASE(comment)
+    assert lvec is None
+    assert has_charges == True
+
 if __name__ == '__main__':
     test_xyz()
+    test_parse_comment_ase()

--- a/dev/test_io.py
+++ b/dev/test_io.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import numpy as np
+
+sys.path.append('..')
+from pyProbeParticle.basUtils import loadXYZ, saveXYZ
+from pyProbeParticle.elements import ELEMENTS
+
+def test_xyz():
+
+    N = 20
+    test_file = 'io_test.xyz'
+
+    xyzs = 10*np.random.rand(N, 3)
+    Zs = np.random.randint(1, 100, N)
+    elems = [ELEMENTS[z-1][1] for z in Zs]
+    qs = np.random.rand(N)
+    comment = 'test comment'
+
+    saveXYZ(test_file, xyzs, elems, qs, comment)
+    xyzs_, Zs_, qs_, comment_ = loadXYZ(test_file)
+
+    assert np.allclose(xyzs, xyzs_)
+    assert np.allclose(Zs, Zs_)
+    assert np.allclose(qs, qs_)
+    assert comment == comment_
+
+    saveXYZ(test_file, xyzs, Zs, qs=None)
+    _, _, qs_, _ = loadXYZ(test_file)
+    assert np.allclose(qs_, np.zeros(N))
+
+    os.remove(test_file)
+
+if __name__ == '__main__':
+    test_xyz()

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -27,6 +27,9 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = []
 
+# Enable writing multiple return values for Google-style docstrings
+napoleon_custom_sections = [('Returns', 'params_style')]
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/examples/CorrectionLoopGraphene/test_CorrectionLoop.py
+++ b/examples/CorrectionLoopGraphene/test_CorrectionLoop.py
@@ -28,7 +28,7 @@ def Job_CorrectionLoop_SimpleRandom( simulator, geom_fname="input.xyz", geom_fna
     '''
     corrector = Corrector()
     corrector.logImgName = "AFM_Err"
-    corrector.xyzLogFile = open( "CorrectorLog.xyz", "w")
+    corrector.xyzLogFile = "CorrectorLog.xyz"
     corrector.plt = plt
     corrector.izPlot = -1
     nscan = simulator.scan_dim; 
@@ -62,7 +62,6 @@ def Job_CorrectionLoop_SimpleRandom( simulator, geom_fname="input.xyz", geom_fna
     #AFMRef = np.roll( AFMRef, -6, axis=1 );
 
     looper = CorrectionLoop(None, simulator, None, None, corrector)
-    #looper.xyzLogFile = open( "CorrectionLoopLog.xyz", "w")
     looper.plt = plt
     #looper.logImgName = "CorrectionLoopAFMLog"
     #looper.logAFMdataName = "AFMs"
@@ -78,8 +77,6 @@ def Job_CorrectionLoop_SimpleRandom( simulator, geom_fname="input.xyz", geom_fna
         Err = looper.iteration(itr=itr)
         if Err < ErrConv:
             break
-    corrector.xyzLogFile.close()
-    #looper.xyzLogFile.close()
 
 # =============== Setup
 
@@ -108,7 +105,7 @@ if __name__ == "__main__":
                             [ 0.0,  0.0, 0.0],
                             [20.0,  0.0, 0.0],
                             [ 0.0, 20.0, 0.0],
-                            [ 0.0,  0.0, 5.0]
+                            [ 0.0,  0.0, 6.0]
                           ]),
         scan_window     = ((2.0, 2.0, 5.0), (18.0, 18.0, 8.0)),
     )

--- a/examples/CorrectionLoopGraphene/test_CorrectionLoop.py
+++ b/examples/CorrectionLoopGraphene/test_CorrectionLoop.py
@@ -36,7 +36,7 @@ def Job_CorrectionLoop_SimpleRandom( simulator, geom_fname="input.xyz", geom_fna
     sw    = simulator.scan_window
 
     def makeMol( fname ):
-        xyzs,Zs,elems,qs  = au.loadAtomsNP(fname)
+        xyzs, Zs, qs, _ = basUtils.loadXYZ(fname)
         xyzs[:,0] += -2
         xyzs[:,1] += -8+20.0
         xyzs[:,2] += -2.2
@@ -50,7 +50,6 @@ def Job_CorrectionLoop_SimpleRandom( simulator, geom_fname="input.xyz", geom_fna
         molecule = Molecule(xyzs,Zs,qs)
         return molecule
 
-    #xyzs_ref,Zs_ref,elems_ref,qs_ref  = au.loadAtomsNP(geom_fname_ref)
     mol_ref = makeMol( geom_fname_ref )
     #simulator.bSaveFF = True                #    DEBUG !!!!!!!!!!!!!!!!!
     simulator.saveFFpre = "ref_"

--- a/examples/Generator/test_trainer.py
+++ b/examples/Generator/test_trainer.py
@@ -88,6 +88,6 @@ for Xs, Ys, mols in trainer:
         plt.close()
         
         mol = mols[j]
-        basUtils.saveXyz(os.path.join(save_dir, f'{counter}_mol.xyz'), mol[:,4].astype(np.int32), mol[:,:4])
+        basUtils.saveXYZ(os.path.join(save_dir, f'{counter}_mol.xyz'), mol[:, :3], mol[:, 4].astype(np.int32), mol[:, 3])
 
         counter += 1

--- a/plot_results.py
+++ b/plot_results.py
@@ -131,7 +131,8 @@ if opt_dict['atoms'] or opt_dict['bonds']:
         speciesFile='atomtypes.ini'
     FFparams=PPU.loadSpecies( speciesFile ) 
     atoms_str="_atoms"
-    atoms = basUtils.loadAtoms( 'input_plot.xyz' )
+    xyzs, Zs, qs, _ = basUtils.loadXYZ('input_plot.xyz')
+    atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
     #print "atoms ", atoms
     FFparams            = PPU.loadSpecies( ) 
     elem_dict           = PPU.getFFdict(FFparams);  #print "elem_dict ", elem_dict

--- a/pyProbeParticle/FARFF.py
+++ b/pyProbeParticle/FARFF.py
@@ -258,6 +258,7 @@ class EngineFARFF():
 if __name__ == "__main__":
 
     import time
+    from . import basUtils
     if __package__ is None:
         import atomicUtils as au
         import GLView as glv
@@ -266,7 +267,7 @@ if __name__ == "__main__":
         from . import GLView as glv
 
     fff = sys.modules[__name__]
-    xyzs,Zs,elems,qs = au.loadAtomsNP("input.xyz")     #; print xyzs
+    xyzs, Zs, qs, _ = basUtils.loadXYZ("input.xyz")
 
     natom  = len(xyzs)
     ndof   = fff.reallocFF(natom)

--- a/pyProbeParticle/MMFF.py
+++ b/pyProbeParticle/MMFF.py
@@ -3,6 +3,7 @@ from   ctypes import c_int, c_double, c_bool, c_float, c_char_p, c_bool, c_void_
 import ctypes
 import os
 from . import cpp_utils
+from . import basUtils
 
 c_double_p = ctypes.POINTER(c_double)
 c_int_p    = ctypes.POINTER(c_int)
@@ -165,19 +166,17 @@ def relaxMolecule(
     pos = getPos (natom)
     
     if bMovie:
-        from . import atomicUtils as au
         if fname is None:
             movie_name = "movie_MMFF.xyz"
         else:
             movie_name = "movie_"+fname
-        with open( movie_name, "w") as fout:
-            for i in range(Nmax/perSave):
-                f = relaxNsteps(perSave, Fconv=Fconv)
-                au.writeToXYZ( fout, elems[mask_dummy], pos[mask_dummy] )
-                if(f<1e-6): break
+        if os.path.exists(movie_name): os.remove(movie_name)
+        for i in range(Nmax/perSave):
+            f = relaxNsteps(perSave, Fconv=Fconv)
+            basUtils.saveXYZ(movie_name, pos[mask_dummy], elems[mask_dummy], append=True)
+            if(f<1e-6): break
     else:
         relaxNsteps(Nmax,Fconv=Fconv)
     if fname is not None:
-        from . import atomicUtils as au
-        au.saveXYZ( elems[mask_dummy], pos[mask_dummy], fname, qs=None )
+        basUtils.saveXYZ(fname, pos[mask_dummy], elems[mask_dummy])
     return pos.copy(),types.copy(),elems

--- a/pyProbeParticle/SimplePot.py
+++ b/pyProbeParticle/SimplePot.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
     Es = eval( ps )  # evaluates potential for array of points (positions of atom A)
     dangs = danglingToArray()
     print( "dangs\n", dangs.shape, xyzs.shape )
-    au.saveXYZ( elems+['H']*len(dangs), np.concatenate( (xyzs, dangs) ), 'dangs.xyz' )
+    basUtils.saveXYZ('dangs.xyz', np.concatenate( (xyzs, dangs) ), elems+['H']*len(dangs))
 
     # ----- plot or store result
     if b3D:

--- a/pyProbeParticle/SimplePot.py
+++ b/pyProbeParticle/SimplePot.py
@@ -10,6 +10,7 @@ import ctypes
 import os
 import sys
 
+from . import basUtils
 from . import atomicUtils as au
 
 # Covalent radii of few atoms in Å
@@ -229,7 +230,8 @@ if __name__ == "__main__":
     print( ps.shape )
 
     # ---- Load Geometry
-    xyzs,Zs,elems,qs = au.loadAtomsNP( 'fail.xyz' )
+    xyzs, Zs, qs, _ = basUtils.loadXYZ('fail.xyz')
+    elems = au.ZsToElems(Zs)
     Rcovs = np.ones(len(xyzs))*0.7
 
     # ----- Here Call SimplePot

--- a/pyProbeParticle/SurfConf.py
+++ b/pyProbeParticle/SurfConf.py
@@ -140,9 +140,12 @@ if __name__ == "__main__":
 
     os.chdir( "/u/25/prokoph1/unix/git/SimpleSimulationEngine/cpp/Build/apps/MolecularEditor2" )
 
-    water   = au.loadAtoms( "inputs/water_T5_ax.xyz" );      #print Campher
-    campher = au.loadAtoms( "inputs/Campher.xyz" );      #print Campher
-    surf    = au.loadAtoms( "inputs/Cu111_6x6_2L.xyz" ); #print Surf
+    xyzs, Zs, qs, _ = au.loadXYZ("inputs/water_T5_ax.xyz")
+    water = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
+    xyzs, Zs, qs, _ = au.loadXYZ("inputs/Campher.xyz")
+    campher = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
+    xyzs, Zs, qs, _ = au.loadXYZ("inputs/Cu111_6x6_2L.xyz")
+    surf = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
 
     cell = [[15.31593,0.0,0.0],[0.0,13.26399,0.0],[0.0,0.0,20.0]]
     rots  = sphereTangentSpace(n=5)

--- a/pyProbeParticle/SurfConf.py
+++ b/pyProbeParticle/SurfConf.py
@@ -5,17 +5,12 @@ import os
 import numpy as np
 
 from . import  RigidMol  as rmol
+from . import basUtils
 
 def combineGeoms(mol,surf):
     es   = mol[0] + surf[0]
     xyzs = np.hstack( [np.array( mol[1:4] ), np.array(  surf[1:4] )] ).transpose().copy()
     return es, xyzs
-
-def writeToXYZ( fout, es, xyzs ):
-    fout.write("%i\n"  %len(xyzs) )
-    fout.write("\n") 
-    for i,xyz in enumerate( xyzs ):
-        fout.write("%s %f %f %f\n"  %( es[i], xyz[0], xyz[1], xyz[2] ) )
 
 def sphereTangentSpace(n=100):
     golden_angle = np.pi * ( 3.0 - np.sqrt(5.0) )
@@ -116,7 +111,8 @@ def getSurfConfs( rots, molFile, pos=[ 5.78, 6.7, 12.24 ], nMaxIter=200, Fconv=0
     for irot,rot in enumerate(rots):
         mol_name = molFile.split("/")[1].split(".")[0]
         print(mol_name)
-        fout = open( "movie_%s_%03i.xyz" %(mol_name,irot) ,'w')
+        fname = "movie_%s_%03i.xyz" %(mol_name,irot)
+        if os.path.exists(fname): os.remove(fname)
         q = mat2quat(rot)
         print("q ", q)
         poses[0,4:8] = q
@@ -125,10 +121,9 @@ def getSurfConfs( rots, molFile, pos=[ 5.78, 6.7, 12.24 ], nMaxIter=200, Fconv=0
             rot_ = quat2mat(poses[0,4:8])
             rots_.append(rot_)
             xyzs[:nAtomMol,:] = apos[:,:]
-            writeToXYZ( fout, es, xyzs )
+            basUtils.saveXYZ(fname, xyzs, es, append=True)
         print("rot  ", rot)
         print("rot_ ", rot_)
-        fout.close()
 
     del  poses
     del  apos

--- a/pyProbeParticle/SurfConf.py
+++ b/pyProbeParticle/SurfConf.py
@@ -111,7 +111,7 @@ def getSurfConfs( rots, molFile, pos=[ 5.78, 6.7, 12.24 ], nMaxIter=200, Fconv=0
     for irot,rot in enumerate(rots):
         mol_name = molFile.split("/")[1].split(".")[0]
         print(mol_name)
-        fname = "movie_%s_%03i.xyz" %(mol_name,irot)
+        fname = f"movie_{mol_name}_{irot:03d}.xyz"
         if os.path.exists(fname): os.remove(fname)
         q = mat2quat(rot)
         print("q ", q)

--- a/pyProbeParticle/atomicUtils.py
+++ b/pyProbeParticle/atomicUtils.py
@@ -173,43 +173,6 @@ def replace( atoms, found, to=17, bond_length=2.0, radial=0.0, prob=0.75 ):
             atoms[iatom,1:] += bvec  
     return atoms
 
-def saveAtoms( atoms, fname, xyz=True ):
-    fout = open(fname,'w')
-    fout.write("%i\n"  %len(atoms) )
-    if xyz==True : fout.write("\n") 
-    for i,atom in enumerate( atoms ):
-        if isinstance( atom[0], str ):
-            fout.write("%s %f %f %f\n"  %( atom[0], atom[1], atom[2], atom[3] ) )
-        else:
-            fout.write("%i %f %f %f\n"  %( atom[0], atom[1], atom[2], atom[3] ) )
-    fout.close() 
-
-def writeToXYZ( fout, es, xyzs, qs=None, Rs=None, commet="" ):
-    fout.write("%i\n"  %len(xyzs) )
-    fout.write(commet+"\n")
-    if   (Rs is not None):
-        for i,xyz in enumerate( xyzs ):
-            fout.write("%s %f %f %f %f %f \n"  %( es[i], xyz[0], xyz[1], xyz[2], qs[i], Rs[i] ) )
-    elif (qs is not None):
-        for i,xyz in enumerate( xyzs ):
-            fout.write("%s %f %f %f %f\n"  %( es[i], xyz[0], xyz[1], xyz[2], qs[i] ) )
-    else:
-        for i,xyz in enumerate( xyzs ):
-            fout.write("%s %f %f %f\n"  %( es[i], xyz[0], xyz[1], xyz[2] ) )
-
-def saveXYZ( es, xyzs, fname, qs=None, Rs=None ):
-    print(">>>>>",fname,"<<<<<")
-    fout = open(fname, "w")
-    writeToXYZ( fout, es, xyzs, qs, Rs=Rs )
-    fout.close() 
-
-def makeMovie( fname, n, es, func ):
-    fout = open(fname, "w")
-    for i in range(n):
-        xyzs, qs = func(i)
-        writeToXYZ( fout, es, xyzs, qs, commet=("frame %i " %i) )
-    fout.close() 
-
 def loadCoefs( characters=['s'] ):
     dens = None
     coefs = []

--- a/pyProbeParticle/atomicUtils.py
+++ b/pyProbeParticle/atomicUtils.py
@@ -210,69 +210,6 @@ def makeMovie( fname, n, es, func ):
         writeToXYZ( fout, es, xyzs, qs, commet=("frame %i " %i) )
     fout.close() 
 
-def loadAtomsNP(fname):
-    xyzs   = [] 
-    Zs     = []
-    enames = []
-    qs     = []
-    with open(fname, 'r') as f:
-        for line in f:
-            wds = line.split()
-            try:
-                xyzs.append( ( float(wds[1]), float(wds[2]), float(wds[3]) ) )
-                try:
-                    iz    = int(wds[0]) 
-                    Zs    .append(iz)
-                    enames.append( elements.ELEMENTS[iz] )
-                except:
-                    ename = wds[0]
-                    enames.append( ename )
-                    Zs    .append( elements.ELEMENT_DICT[ename][0] )
-                try:
-                    q = float(wds[4])
-                except:
-                    q = 0
-                qs.append(q)
-            except:
-                print("cannot interpet line: ", line)
-                continue
-    xyzs = np.array( xyzs )
-    Zs   = np.array( Zs, dtype=np.int32 )
-    qs   = np.array(qs)
-    return xyzs,Zs,enames,qs
-
-def loadAtoms( name ):
-    f = open(name,"r")
-    n=0;
-    l = f.readline()
-    try:
-        n=int(l)
-    except:
-        raise ValueError("First line of a xyz file should contain the number of atoms. Aborting...")
-    line = f.readline() 
-    if (n>0):
-        n=int(l)
-        e=[];x=[];y=[]; z=[]; q=[]
-        i = 0;
-        for line in f:
-            words=line.split()
-            nw = len( words)
-            ie = None
-            if( nw >=4 ):
-                e.append( words[0] )
-                x.append( float(words[1]) )
-                y.append( float(words[2]) )
-                z.append( float(words[3]) )
-                if ( nw >=5 ):
-                    q.append( float(words[4]) )
-                else:
-                    q.append( 0.0 )
-                i+=1
-            else:
-                print(" skipped line : ", line)
-    f.close()
-    return [ e,x,y,z,q ]
-
 def loadCoefs( characters=['s'] ):
     dens = None
     coefs = []
@@ -314,6 +251,8 @@ def histR( ps, dbin=None, Rmax=None, weights=None ):
     print(( rs.shape, weights.shape ))
     return np.histogram(rs, bins, weights=weights)
 
-
+def ZsToElems(Zs):
+    '''Convert atomic numbers to element symbols.'''
+    return [elements.ELEMENTS[Z-1][1] for Z in Zs]
 
     

--- a/pyProbeParticle/basUtils.py
+++ b/pyProbeParticle/basUtils.py
@@ -347,6 +347,9 @@ def loadGeometry(fname=None,params=None):
         elif not has_charges:
             # The fifth column in the ASE format was not charges, so ignore what was read from the file
             qs = np.zeros(len(qs), dtype=np.float32)
+        if _not_actually_charge(qs):
+            # qs is not actually charges based on some heuristics
+            qs = np.zeros(len(qs), dtype=np.float32)
         atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
     elif(is_cube):
         atoms = loadAtomsCUBE(fname)
@@ -392,6 +395,13 @@ def parseCommentASE(comment):
         has_charges = False
     
     return lvec, has_charges
+
+def _not_actually_charge(qs):
+    if abs(sum(qs)) > 3:
+        return True
+    if np.abs(qs).max() > 3:
+        return True
+    return False
 
 def findBonds( atoms, iZs, sc, ELEMENTS = elements.ELEMENTS, FFparams=None ):
     bonds = []

--- a/pyProbeParticle/basUtils.py
+++ b/pyProbeParticle/basUtils.py
@@ -204,12 +204,12 @@ def saveGeomXSF( fname,elems,xyzs, primvec, convvec=None, bTransposed=False ):
             zs = xyzs[2]
             for i in range(len(elems)):
                 f.write( str(elems[i] ) ); 
-                f.write( " %10.10f %10.10f %10.10f\n" %(xs[i], ys[i], zs[i]) )
+                f.write( f" {xs[i]:10.10f} {ys[i]:10.10f} {zs[i]:10.10f}\n" )
         else:
             for i in range(len(elems)):
                 xyzsi = xyzs[i]
                 f.write( str(elems[i] ) ); 
-                f.write( " %10.10f %10.10f %10.10f\n" %(xyzsi[0], xyzsi[1], xyzsi[2]) )
+                f.write( f" {xyzsi[0]:10.10f} {xyzsi[1]:10.10f} {xyzsi[2]:10.10f}\n" )
         f.write( '\n' )
 
 def loadXSFGeom( fname ):

--- a/pyProbeParticle/basUtils.py
+++ b/pyProbeParticle/basUtils.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
-from . import elements
-#import elements
+import os
 import math
 import numpy as np
+
+from . import elements
 
 verbose = 0
 
@@ -59,9 +60,9 @@ def loadXYZ(fname):
 
     return xyzs, Zs, qs, comment
 
-def saveXYZ(fname, xyzs, Zs, qs=None, comment=''):
+def saveXYZ(fname, xyzs, Zs, qs=None, comment='', append=False):
     '''
-    Save atom types, positions and, optionally, charges to an xyz file.
+    Save atom types, positions, and, (optionally) charges to an xyz file.
 
     Arguments:
         fname: str. Path to file.
@@ -70,15 +71,19 @@ def saveXYZ(fname, xyzs, Zs, qs=None, comment=''):
         qs: np.ndarray of shape (N_atoms) or None. If not None, the partial charges of atoms written as
             the fifth column into the xyz file.
         comment: str. Comment string written to the second line of the xyz file.
+        append: bool. Append to file instead of overwriting if it already exists. Useful for creating
+            movies of changing structures.
     '''
     N = len(xyzs)
-    with open(fname, 'w') as f:
+    mode = 'a' if append else 'w'
+    file_exists = os.path.exists(fname)
+    with open(fname, mode) as f:
+        if append and file_exists: f.write('\n')
         f.write(f'{N}\n{comment}\n')
         for i in range(N):
             f.write(f'{Zs[i]} {xyzs[i, 0]} {xyzs[i, 1]} {xyzs[i, 2]}')
-            if qs is not None:
-                f.write(f' {qs[i]}')
-            f.write('\n')
+            if qs is not None: f.write(f' {qs[i]}')
+            if i < (N-1): f.write('\n')
 
 def loadGeometryIN(fname):
     Zs = []; xyzs = []; lvec = []
@@ -147,20 +152,6 @@ def writeMatrix( fout, mat ):
         for num in v: fout.write(' %f ' %num )
         fout.write('\n')
 
-def writeAtoms( f, elems, xyzs ):
-    for i in range(len(elems)):
-        xyzsi = xyzs[i]
-        f.write( str(elems[i] ) ); 
-        f.write( " %10.10f %10.10f %10.10f\n" %(xyzsi[0], xyzsi[1], xyzsi[2]) )
-
-def writeAtomsTransposed( f, elems, xyzs ):
-    xs = xyzs[0]
-    ys = xyzs[1]
-    zs = xyzs[2]
-    for i in range(len(elems)):
-        f.write( str(elems[i] ) ); 
-        f.write( " %10.10f %10.10f %10.10f\n" %(xs[i], ys[i], zs[i]) )
-
 def saveGeomXSF( fname,elems,xyzs, primvec, convvec=None, bTransposed=False ):
     if convvec is None:
         primvec = convvec
@@ -173,75 +164,18 @@ def saveGeomXSF( fname,elems,xyzs, primvec, convvec=None, bTransposed=False ):
         f.write( 'PRIMCOORD\n' )
         f.write( '%i %i\n' %(len(elems),1) )
         if bTransposed:
-            writeAtomsTransposed( f, elems, xyzs )
+            xs = xyzs[0]
+            ys = xyzs[1]
+            zs = xyzs[2]
+            for i in range(len(elems)):
+                f.write( str(elems[i] ) ); 
+                f.write( " %10.10f %10.10f %10.10f\n" %(xs[i], ys[i], zs[i]) )
         else:
-            writeAtoms( f, elems, xyzs )
+            for i in range(len(elems)):
+                xyzsi = xyzs[i]
+                f.write( str(elems[i] ) ); 
+                f.write( " %10.10f %10.10f %10.10f\n" %(xyzsi[0], xyzsi[1], xyzsi[2]) )
         f.write( '\n' )
-
-def saveXyz_Transposed(fname,elems,xyzs):
-    with open(fname,'w') as f:
-        n = len(elems)
-        f.write( "%i\n" %n )
-        f.write( "#comment\n" )
-        xs = xyzs[0]
-        ys = xyzs[1]
-        zs = xyzs[2]
-        for i in range(n):
-            f.write( "%s %10.10f %10.10f %10.10f\n" %(elems[i], xs[i], ys[i], zs[i] )  )
-
-def saveXyz(fname,elems,xyzs):
-    with open(fname,'w') as f:
-        n = len(elems)
-        f.write( "%i\n" %n )
-        f.write( "#comment\n" )
-        for i in range(n):
-            xyzsi = xyzs[i]
-            f.write( "%s %10.10f %10.10f %10.10f\n" %(elems[i], xyzsi[0], xyzsi[1], xyzsi[2] )  )
-
-def saveXyzq(fname,elems,xyzqs):
-    with open(fname,'w') as f:
-        n = len(elems)
-        f.write( "%i\n" %n )
-        f.write( "#comment\n" )
-        for i in range(n):
-            f.write( "%s %10.10f %10.10f %10.10f %10.10f\n" %(elems[i], xyzs[i][0], xyzs[i][1], xyzs[i][2], xyzs[i][3] )  )
-
-def writeDebugXYZ( fname, lines, poss, pos0=None ):
-    fout  = open(fname,"w")
-    natom = int(lines[0])
-    npos  = len(poss)
-    if pos0 is not None:
-        natom+=1
-        lines.append( "U %f %f %f\n" %(pos0[0], pos0[1], pos0[2]) )
-    fout.write( "%i\n" %(natom + npos) )
-    fout.write( "\n" )
-    for line in lines[2:natom+2]:
-        fout.write( line )
-    for pos in poss:
-        fout.write( "He %f %f %f\n" %(pos[0], pos[1], pos[2]) )
-    fout.write( "\n" )
-
-def writeDebugXYZ_2( fname, atoms, Zs, poss, pos0 ):
-    fout  = open(fname,"w")
-    natom = len(atoms)
-    npos  = len(poss)
-    fout.write( "%i\n" %(natom + npos+1) )
-    fout.write( "\n" )
-    fout.write( "%i %f %f %f\n" %( 92, pos0[0], pos0[1], pos0[2] ) )
-    for i in range(natom):
-        fout.write( "%i %f %f %f\n" %( Zs[i],atoms[i][0], atoms[i][1], atoms[i][2]) )
-    for pos in poss:
-        fout.write( "He %f %f %f\n" %(pos[0], pos[1], pos[2]) )
-    fout.write( "\n" )
-
-def writeDebugXYZ__( fname, atoms, Zs ):
-    fout  = open(fname,"w")
-    natom = len(atoms)
-    fout.write( "%i\n" %(natom ) )
-    fout.write( "\n" )
-    for i in range(natom):
-        fout.write( "%i %f %f %f\n" %( Zs[i],atoms[i][0], atoms[i][1], atoms[i][2]) )
-    fout.write( "\n" )
 
 def loadXSFGeom( fname ):
     f = open(fname )

--- a/pyProbeParticle/basUtils.py
+++ b/pyProbeParticle/basUtils.py
@@ -83,17 +83,7 @@ def _getCharges(comment, extra_cols):
     else:
         # Not ASE format, so just take first column
         qs = np.array([float(ex[0]) for ex in extra_cols], dtype=np.float64)
-        if _notActuallyCharge(qs):
-            # qs is not actually charges based on some heuristics
-            qs = np.zeros(len(qs), dtype=np.float64)
     return qs
-
-def _notActuallyCharge(qs):
-    if abs(sum(qs)) > 3:
-        return True
-    if np.abs(qs).max() > 3:
-        return True
-    return False
 
 def saveXYZ(fname, xyzs, Zs, qs=None, comment='', append=False):
     '''

--- a/pyProbeParticle/ml/CorrectionLoop.py
+++ b/pyProbeParticle/ml/CorrectionLoop.py
@@ -341,7 +341,7 @@ class CorrectionLoop():
 
     def iteration(self, itr=0 ):
         if self.xyzLogFile is not None:
-           basUtils.saveXYZ( self.xyzLogFile, self.molecule.xyzs, self.molecule.Zs, qs=self.molecule.qs, comment=("CorrectionLoop.iteration [%i] " %itr) )
+           basUtils.saveXYZ( self.xyzLogFile, self.molecule.xyzs, self.molecule.Zs, qs=self.molecule.qs, comment=(f"CorrectionLoop.iteration [{itr}] ") )
         # Get AFM
         xyzs, qs, Zs = self.molecule.xyzs, self.molecule.qs, self.molecule.Zs
         AFMs  = self.simulator(xyzs, Zs, qs)
@@ -380,7 +380,7 @@ def Job_trainCorrector( simulator, geom_fname="input.xyz", nstep=10 ):
     basUtils.saveXYZ( xyzfile, mol.xyzs, mol.Zs, qs=mol.qs, comment="# start " )
     for itr in range(nstep):
         Xs1,Xs2,mol1,mol2  = trainer[itr]
-        basUtils.saveXYZ( xyzfile, mol2.xyzs, mol2.Zs, qs=mol2.qs, comment=("# mutation %i " %itr), append=True)
+        basUtils.saveXYZ( xyzfile, mol2.xyzs, mol2.Zs, qs=mol2.qs, comment=(f"# mutation {itr} "), append=True)
         plt.figure(figsize=(10,5))
         plt.subplot(1,2,1); plt.imshow(Xs1[:,:,iz], origin='upper', extent=extent); plt.scatter( mol1.xyzs[:,0], mol1.xyzs[:,1], s=mol1.Zs*sc, c=cm.rainbow( mol1.xyzs[:,2] )  )
         plt.subplot(1,2,2); plt.imshow(Xs2[:,:,iz], origin='upper', extent=extent); plt.scatter( mol2.xyzs[:,0], mol2.xyzs[:,1], s=mol2.Zs*sc, c=cm.rainbow( mol2.xyzs[:,2] ) )

--- a/pyProbeParticle/ml/CorrectionLoop.py
+++ b/pyProbeParticle/ml/CorrectionLoop.py
@@ -363,7 +363,7 @@ def Job_trainCorrector( simulator, geom_fname="input.xyz", nstep=10 ):
     iz = -10
     mutator = Mutator()
     trainer = CorrectorTrainer( simulator, mutator, molCreator=None )
-    xyzs,Zs,elems,qs = au.loadAtomsNP(geom_fname)
+    xyzs, Zs, qs, _ = basUtils.loadXYZ(geom_fname)
 
     sw = simulator.scan_window
     scan_center = np.array([sw[1][0] + sw[0][0], sw[1][1] + sw[0][1]]) / 2
@@ -400,7 +400,7 @@ def Job_CorrectionLoop( simulator, atoms, bonds, geom_fname="input.xyz", nstep=1
     looper.xyzLogFile = open( "CorrectionLoopLog.xyz", "w")
     looper.logImgName = "CorrectionLoopAFMLog"
     looper.logAFMdataName = "AFMs"
-    xyzs,Zs,elems,qs = au.loadAtomsNP(geom_fname)
+    xyzs, Zs, qs, _ = basUtils.loadXYZ(geom_fname)
 
     sw = simulator.scan_window
     scan_center = np.array([sw[1][0] + sw[0][0], sw[1][1] + sw[0][1]]) / 2

--- a/pyProbeParticle/ml/CorrectionLoop.py
+++ b/pyProbeParticle/ml/CorrectionLoop.py
@@ -341,7 +341,7 @@ class CorrectionLoop():
 
     def iteration(self, itr=0 ):
         if self.xyzLogFile is not None:
-           au.writeToXYZ( self.xyzLogFile, self.molecule.Zs, self.molecule.xyzs, qs=self.molecule.qs, commet=("CorrectionLoop.iteration [%i] " %itr) )
+           basUtils.saveXYZ( self.xyzLogFile, self.molecule.xyzs, self.molecule.Zs, qs=self.molecule.qs, comment=("CorrectionLoop.iteration [%i] " %itr) )
         # Get AFM
         xyzs, qs, Zs = self.molecule.xyzs, self.molecule.qs, self.molecule.Zs
         AFMs  = self.simulator(xyzs, Zs, qs)
@@ -376,17 +376,16 @@ def Job_trainCorrector( simulator, geom_fname="input.xyz", nstep=10 ):
     extent=( simulator.scan_window[0][0], simulator.scan_window[1][0], simulator.scan_window[0][1], simulator.scan_window[1][1] )
     sc = 3.0
 
-    xyzfile = open("geomMutations.xyz","w")
-    au.writeToXYZ( xyzfile, mol.Zs, mol.xyzs, qs=mol.qs, commet="# start " )
+    xyzfile = "geomMutations.xyz"
+    basUtils.saveXYZ( xyzfile, mol.xyzs, mol.Zs, qs=mol.qs, comment="# start " )
     for itr in range(nstep):
         Xs1,Xs2,mol1,mol2  = trainer[itr]
-        au.writeToXYZ( xyzfile, mol2.Zs,  mol2.xyzs, qs=mol2.qs, commet=("# mutation %i " %itr) )
+        basUtils.saveXYZ( xyzfile, mol2.xyzs, mol2.Zs, qs=mol2.qs, comment=("# mutation %i " %itr), append=True)
         plt.figure(figsize=(10,5))
         plt.subplot(1,2,1); plt.imshow(Xs1[:,:,iz], origin='upper', extent=extent); plt.scatter( mol1.xyzs[:,0], mol1.xyzs[:,1], s=mol1.Zs*sc, c=cm.rainbow( mol1.xyzs[:,2] )  )
         plt.subplot(1,2,2); plt.imshow(Xs2[:,:,iz], origin='upper', extent=extent); plt.scatter( mol2.xyzs[:,0], mol2.xyzs[:,1], s=mol2.Zs*sc, c=cm.rainbow( mol2.xyzs[:,2] ) )
         plt.savefig( "CorrectorTrainAFM_%03i.png" %itr )
         plt.close()
-    xyzfile.close()
 
 def Job_CorrectionLoop( simulator, atoms, bonds, geom_fname="input.xyz", nstep=10 ):
     relaxator = FARFF.EngineFARFF()
@@ -397,7 +396,7 @@ def Job_CorrectionLoop( simulator, atoms, bonds, geom_fname="input.xyz", nstep=1
     AFMRef = np.load('AFMref.npy')
 
     looper = CorrectionLoop(relaxator, simulator, atoms, bonds, corrector)
-    looper.xyzLogFile = open( "CorrectionLoopLog.xyz", "w")
+    looper.xyzLogFile = "CorrectionLoopLog.xyz"
     looper.logImgName = "CorrectionLoopAFMLog"
     looper.logAFMdataName = "AFMs"
     xyzs, Zs, qs, _ = basUtils.loadXYZ(geom_fname)
@@ -423,8 +422,6 @@ def Job_CorrectionLoop( simulator, atoms, bonds, geom_fname="input.xyz", nstep=1
         Err = looper.iteration(itr=itr)
         if Err < ErrConv:
             break
-
-    looper.xyzLogFile.close()
 
 # ========================================================================
 

--- a/pyProbeParticle/ml/Corrector.py
+++ b/pyProbeParticle/ml/Corrector.py
@@ -275,9 +275,9 @@ class Corrector():
 
 def _saveXYZDebug(es, xyzs, fname, qs, Rs):
     with open(fname, 'w') as fout:
-        fout.write("%i\n\n"  %len(xyzs) )
+        fout.write(f"{len(xyzs)}\n\n")
         for i,xyz in enumerate( xyzs ):
-            fout.write("%s %f %f %f %f %f \n"  %( es[i], xyz[0], xyz[1], xyz[2], qs[i], Rs[i] ) )
+            fout.write(f"{es[i]} {xyz[0]} {xyz[1]} {xyz[2]} {qs[i]} {Rs[i]} \n")
 
 # ======================================================
 # ================== Class  Mutator

--- a/pyProbeParticle/ml/Corrector.py
+++ b/pyProbeParticle/ml/Corrector.py
@@ -56,7 +56,7 @@ class Molecule():
         return np.array( [x,y,z] )/n
 
     def toXYZ( self, xyzfile, comment="#comment" ):
-        au.writeToXYZ( xyzfile, self.Zs, self.xyzs, qs=self.qs, commet=comment )
+        basUtils.saveXYZ( xyzfile, self.xyzs, self.Zs, qs=self.qs, comment=comment )
 
 # ======================================================
 # ================== free function operating on Moleule
@@ -232,7 +232,7 @@ class Corrector():
         Rs    = np.concatenate( [ np.ones(na0),Ws] )
         xyzs2 = np.concatenate( [ molIn.xyzs,  ps], axis=0 )
         print( "xyzs2.shape ", xyzs2.shape ) 
-        au.saveXYZ( Zs2, xyzs2, 'debug_genAtomWs.xyz', qs=([0.0]*(na0+nps)),  Rs=Rs )
+        _saveXYZDebug( Zs2, xyzs2, 'debug_genAtomWs.xyz', qs=([0.0]*(na0+nps)),  Rs=Rs )
 
     def try_improve(self, molIn, AFMs, AFMRef, span, itr=0 ):
         AFMdiff = AFMs - AFMRef
@@ -272,6 +272,12 @@ class Corrector():
                 self.best_mol.toXYZ( self.xyzLogFile, comment=("Corrector [%i] Err %g " %(itr,self.best_E) ) )
         molOut = self.modifyStructure( self.best_mol )
         return Err, molOut
+
+def _saveXYZDebug(es, xyzs, fname, qs, Rs):
+    with open(fname, 'w') as fout:
+        fout.write("%i\n\n"  %len(xyzs) )
+        for i,xyz in enumerate( xyzs ):
+            fout.write("%s %f %f %f %f %f \n"  %( es[i], xyz[0], xyz[1], xyz[2], qs[i], Rs[i] ) )
 
 # ======================================================
 # ================== Class  Mutator

--- a/pyProbeParticle/ml/Generator.py
+++ b/pyProbeParticle/ml/Generator.py
@@ -152,9 +152,8 @@ class InverseAFMtrainer:
         '''
         self.molecules = []
         for path in self.paths:
-            with open(path, 'r') as f:
-                xyzs, Zs, _, qs = basUtils.loadAtomsLines(f.readlines())
-                self.molecules.append(np.concatenate([xyzs, qs[:,None], Zs[:,None]], axis=1))
+            xyzs, Zs, qs, _ = basUtils.loadXYZ(path)
+            self.molecules.append(np.concatenate([xyzs, qs[:,None], Zs[:,None]], axis=1))
     
     def handle_positions(self):
         '''

--- a/pyProbeParticle/ocl/AFMulator.py
+++ b/pyProbeParticle/ocl/AFMulator.py
@@ -10,7 +10,7 @@ from . import relax     as oclr
 from . import oclUtils  as oclu
 
 from .field import HartreePotential, MultipoleTipDensity, hartreeFromFile
-from ..basUtils import loadAtomsLines
+from ..basUtils import loadXYZ
 from ..PPPlot import plotImages
 
 VALID_SIZES = np.array([16, 32, 64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048])
@@ -450,8 +450,7 @@ def quick_afm(file_path, scan_size=(16, 16), offset=(0, 0), distance=8.0, scan_s
         Qs = [0, 0, 0, 0]
         QZs = [0, 0, 0, 0]
     elif file_path.endswith('.xyz'):
-        with open(file_path, 'r') as f:
-            xyzs, Zs, _, qs = loadAtomsLines(f.readlines())
+        xyzs, Zs, qs, _ = loadXYZ(file_path)
         multipole = {}
         if tip == 's':
             Qs = [charge, 0, 0, 0]

--- a/utilities/xsf2png.py
+++ b/utilities/xsf2png.py
@@ -38,7 +38,8 @@ parser.add_option( "--bonds",    action="store_true", default=False, help="plot 
 atoms = None
 bonds = None
 if options.atoms:
-    atoms = basUtils.loadAtoms( options.atoms )
+    xyzs, Zs, qs, _ = basUtils.loadXYZ(options.atoms)
+    atoms = [list(Zs), list(xyzs[:, 0]), list(xyzs[:, 1]), list(xyzs[:, 2]), list(qs)]
     if os.path.isfile( 'atomtypes.ini' ):
         print(">> LOADING LOCAL atomtypes.ini")  
         FFparams=PPU.loadSpecies( 'atomtypes.ini' ) 


### PR DESCRIPTION
Fixes #24 

Deletes all old xyz IO functions and replaces them with new ones called `loadXYZ` and `saveXYZ` in all relevant places. Also handle the extended xyz file format used by ASE, in order to pick out the correct column for charges and interpret the comment line for the lattice vectors.