### PR TITLE
apos -> poss

### DIFF
--- a/cpp/ReactiveFF.cpp
+++ b/cpp/ReactiveFF.cpp
@@ -99,7 +99,7 @@ void setTypes( int natoms, int* types ){
 void clean(){ ff.cleanAux(); }
 
 int*    getTypes (){ return (int*)   ff.types;  }
-double* getPoss  (){ return (double*)ff.apos;   }
+double* getPoss  (){ return (double*)ff.poss;   }
 double* getQrots (){ return (double*)ff.qrots;  }
 double* getHbonds(){ return (double*)ff.hbonds; }
 double* getEbonds(){ return (double*)ff.ebonds; }


### PR DESCRIPTION
seems to be some leftover from old code - with `apos` it doesn't compile, with `poss` it does.