### PR TITLE
Fix for missing submodules in package build.

### DIFF
--- a/ppafm/defaults/__init__.py
+++ b/ppafm/defaults/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/ppafm/ml/__init__.py
+++ b/ppafm/ml/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/ppafm/ocl/__init__.py
+++ b/ppafm/ocl/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3


### PR DESCRIPTION
Fixes #58.

Adds `__init__.py` to the submodules.